### PR TITLE
"Exit" tray icon option doesn't actual terminate MouseUnsnag.exe

### DIFF
--- a/MouseUnSnag/TrayIconApplicationContext.cs
+++ b/MouseUnSnag/TrayIconApplicationContext.cs
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
-using MouseUnSnag.CommandLine;
 using MouseUnSnag.Configuration;
 
 namespace MouseUnSnag
@@ -87,7 +87,7 @@ namespace MouseUnSnag
                 new MenuItem("Exit", delegate
                 {
                     _trayIcon.Visible = false;
-                    Application.Exit();
+                    Environment.Exit(0);
                 })
             };
         }


### PR DESCRIPTION
I noticed that `MouseUnsnag.exe` didn't actually close when clicking the `Exit` option in the system tray icon menu. I'm not 100% sure what I'm doing here since I don't typically build windows GUI apps, so my initial fix was to just swap out `Application.Exit()`  with `Environment.Exit(0)` which probably just unceremoniously kills the application. 

My _guess_ (being a noob in C#) is that `Application.Exit()`  should have allowed the process to exit gracefully on its own, but since maybe it's hooking into something (maybe via `MouseHookHandler`), it stays running until those handlers are closed, maybe? Not sure. I'm guessing this fix works since it's probably taking a sledge hammer to everything. But again... I'm dumb and I don't really know for sure yet 😬

~~cc @drewnoakes since you were the original author of [this option here (back in 2018)](https://github.com/MouseUnSnag/MouseUnSnag/commit/e0051c5c5522a216d1530ecba78044d341e5d402#diff-8d3d7c2beb0b04a1091038d0241e1b3093d5243dfb6b632e889536224cd47c1dR37). Do you know if issue existed back then in your version as well?~~ 

**EDIT:** Never mind, I just found that this was caused by some odd undocumented functionality associated with a separate thread being created to watch the caps lock key, will address in #6 and in a separate PR.