### PR TITLE
Improve screen jumping algorithm

### DIFF
--- a/MouseUnSnag/GeometryUtil.cs
+++ b/MouseUnSnag/GeometryUtil.cs
@@ -21,6 +21,13 @@ namespace MouseUnSnag
         public static Point Sign(Point p) => new Point(Math.Sign(p.X), Math.Sign(p.Y));
 
         /// <summary>
+        /// Return the magnitude of Point p.
+        /// </summary>
+        /// <param name="p"><see cref="Point"/> of which to get the sign</param>
+        /// <returns><see cref="Point"/> where X, Y have values corresponding to their sign</returns>
+        public static double Magnitude(Point p) => Math.Sqrt(p.X * p.X + p.Y * p.Y);
+
+        /// <summary>
         /// "Direction" vector from P1 to P2. X/Y of returned point will have values
         /// of -1, 0, or 1 only (vector is not normalized to length 1).
         /// </summary>
@@ -85,6 +92,22 @@ namespace MouseUnSnag
         /// <param name="p"><see cref="Point"/></param>
         /// <returns><see cref="Point"/></returns>
         public static Point OutsideDirection(Rectangle r, Point p) => Sign(OutsideDistance(r, p));
+
+        /// <summary>
+        /// In which direction(s) is(are) the rectangle r2 outside of the rectangle r1? If r2
+        /// overlaps r1, then this returns (0,0). Else X and/or Y can be either -1 or +1, depending
+        /// on which direction r2 is outside r1. For a rectangle to be diagonal to another rectangle,
+        /// it must not overlap horizontal or vertically.
+        /// </summary>
+        /// <param name="r"><see cref="Rectangle"/></param>
+        /// <param name="p"><see cref="Point"/></param>
+        /// <returns><see cref="Point"/></returns>
+        public static Point OutsideDirection(Rectangle r1, Rectangle r2) => (OverlapX(r1, r2), OverlapY(r1, r2)) switch {
+            (false, false) => new Point(Math.Sign(r1.Left - r2.Left), Math.Sign(r1.Top - r2.Top)),
+            (false, true) => new Point(Math.Sign(r1.Left - r2.Left), 0),
+            (true, false) => new Point(0, Math.Sign(r1.Top - r2.Top)),
+            (true, true) => new Point(0, 0),
+        };
 
 
         /// <summary>

--- a/MouseUnSnag/GeometryUtil.cs
+++ b/MouseUnSnag/GeometryUtil.cs
@@ -103,9 +103,9 @@ namespace MouseUnSnag
         /// <param name="p"><see cref="Point"/></param>
         /// <returns><see cref="Point"/></returns>
         public static Point OutsideDirection(Rectangle r1, Rectangle r2) => (OverlapX(r1, r2), OverlapY(r1, r2)) switch {
-            (false, false) => new Point(Math.Sign(r1.Left - r2.Left), Math.Sign(r1.Top - r2.Top)),
-            (false, true) => new Point(Math.Sign(r1.Left - r2.Left), 0),
-            (true, false) => new Point(0, Math.Sign(r1.Top - r2.Top)),
+            (false, false) => new Point(Math.Sign(r2.Left - r1.Left), Math.Sign(r2.Top - r1.Top)),
+            (false, true) => new Point(Math.Sign(r2.Left - r1.Left), 0),
+            (true, false) => new Point(0, Math.Sign(r2.Top - r1.Top)),
             (true, true) => new Point(0, 0),
         };
 

--- a/MouseUnSnag/MouseLogic.cs
+++ b/MouseUnSnag/MouseLogic.cs
@@ -114,8 +114,7 @@ namespace MouseUnSnag
                 return false;
             }
 
-            var jumpScreen = displays.ScreenInDirection(stuckDirection, cursorScreen.Bounds);
-
+            var jumpScreen = displays.JumpScreen(mouse, cursorScreen.Bounds);
 
             if (mouseScreen != null)
             {

--- a/MouseUnSnag/MouseLogic.cs
+++ b/MouseUnSnag/MouseLogic.cs
@@ -128,6 +128,11 @@ namespace MouseUnSnag
             }
             else if (jumpScreen != null)
             {
+                if (stuckDirection.X != 0 && stuckDirection.Y != 0 && !Options.Unstick) {
+                    Debug.WriteLine("  > Refusing to jump diagonally while unstick disabled");
+                    return false;
+                }
+
                 Debug.WriteLine("  > JumpScreen");
                 if (!Options.Jump)
                     return false;

--- a/MouseUnSnag/ScreenHandling/DisplayList.cs
+++ b/MouseUnSnag/ScreenHandling/DisplayList.cs
@@ -77,8 +77,8 @@ namespace MouseUnSnag.ScreenHandling
         /// <returns></returns>
         private IEnumerable<Display> ScreensInDirection(Point dir, Rectangle curScreen) => All.Where(screen => {
             var screenDir = GeometryUtil.OutsideDirection(curScreen, screen.Bounds);
-            return screenDir.X == dir.X && Math.Abs(screenDir.Y - dir.Y) <= 1.0
-                || screenDir.Y == dir.Y && Math.Abs(screenDir.X - dir.X) <= 1.0;
+            return screenDir.X * dir.X == 1 && Math.Abs(screenDir.Y - dir.Y) <= 1
+                || screenDir.Y * dir.Y == 1 && Math.Abs(screenDir.X - dir.X) <= 1;
         });
 
         /// <summary>

--- a/MouseUnSnagTests/ScreenHandling/DisplayListTests.cs
+++ b/MouseUnSnagTests/ScreenHandling/DisplayListTests.cs
@@ -50,5 +50,21 @@ namespace MouseUnSnag.ScreenHandling.Tests
             Assert.IsNotNull(screenInfo);
             Console.WriteLine(screenInfo);
         }
+
+        [TestMethod()]
+        public void JumpScreenTest()
+        {
+            // Test arragements from issue #16
+            var top_left = new VirtualScreen(32, new Rectangle(0, 0, 800, 600), "top_left", true, new Rectangle(0, 0, 800, 600));
+            var top_right = new VirtualScreen(32, new Rectangle(800, 0, 800, 600), "top_right", true, new Rectangle(800, 0, 800, 600));
+            var bottom_left = new VirtualScreen(32, new Rectangle(0, 600, 800, 600), "bottom_left", true, new Rectangle(0, 600, 800, 600));
+            var bottom_right = new VirtualScreen(32, new Rectangle(800, 600, 800, 600), "bottom_right", true, new Rectangle(800, 600, 800, 600));
+            var arragement1 = new DisplayList(new []{top_left, top_right, bottom_right});
+            var arragement2 = new DisplayList(new []{bottom_left, top_left, top_right});
+
+            Assert.AreEqual(arragement1.JumpScreen(new Point(810, 0), top_left.Bounds).Screen, top_right);
+            Assert.AreEqual(arragement2.JumpScreen(new Point(790, 0), top_right.Bounds).Screen, top_left);
+            Assert.AreEqual(arragement2.JumpScreen(new Point(790, -10), top_right.Bounds).Screen, top_left);
+        }
     }
 }


### PR DESCRIPTION
The current algorithm is roughly:
1. For each monitor in the same order the OS numbers them
    1. If the cursor moved off the current monitor horizontally (including if it also moved vertically, i.e. diagonally), and the monitor's edge lines up exactly with the current monitor, jump to that monitor
    2. if the cursor moved of the current monitor vertically, and the monitor's edge lines up exactly with the current monitor, jump to that monitor

This causes errors, as shown in issue #16, when more than one monitor is in the direction the cursor leaves the screen. Instead we'd like to pick the "best" screen in the direction the cursor leaves the screen. "Best" isn't well defined, but closest by euclidean distance should be a reasonable approximation.

The new algorithm is:
1. Filter the list of all monitors to just those in the direction the cursor left the current monitor.
2. Jump to the monitor in the filtered list which is closest to where the cursor left the current monitor.

Fixes #16