### PR TITLE
Change missed TestMethod to Test from NUnit conversion

### DIFF
--- a/MouseUnSnagTests/ScreenHandling/DisplayListTests.cs
+++ b/MouseUnSnagTests/ScreenHandling/DisplayListTests.cs
@@ -47,7 +47,7 @@ namespace MouseUnSnag.ScreenHandling.Tests
             Console.WriteLine(screenInfo);
         }
 
-        [TestMethod()]
+        [Test]
         public void JumpScreenTest()
         {
             // Test arragements from issue #16


### PR DESCRIPTION
When converting from Visual Studio unit test framework to NUnit, this test annotation was missed, causing the build to fail.