### PR TITLE
Address remaining issues for v2.2 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,11 @@ jobs:
         msbuild %SolutionName% /restore /property:Configuration=%Configuration% /property:Platform="Any CPU"
       env:
         Configuration: ${{ matrix.configuration }}
+    - name: Upload Executable Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: MouseUnSnag
+        path: MouseUnSnag/bin/Release/MouseUnSnag.exe
     - name: Test Solution
       shell: cmd
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
         Configuration: ${{ matrix.configuration }}
     - name: Upload Executable Artifact
       uses: actions/upload-artifact@v3
+      if: ${{ matrix.configuration == 'Release' }}
       with:
         name: MouseUnSnag
         path: MouseUnSnag/bin/Release/MouseUnSnag.exe

--- a/MouseUnSnag/CommandLine/CommandLineParser.cs
+++ b/MouseUnSnag/CommandLine/CommandLineParser.cs
@@ -35,9 +35,6 @@ namespace MouseUnSnag.CommandLine
                     case 'W':
                         options.Wrap = flagValue;
                         break;
-                    case 'R':
-                        options.Rescale = flagValue;
-                        break;
                     default:
                         DisplayUsageAndExit($"Invalid Argument: {arg}");
                         break;

--- a/MouseUnSnag/Configuration/Options.cs
+++ b/MouseUnSnag/Configuration/Options.cs
@@ -7,7 +7,6 @@ namespace MouseUnSnag.Configuration
         private bool _unstick = true;
         private bool _jump = true;
         private bool _wrap = true;
-        private bool _rescale;
 
         public bool Unstick
         {
@@ -42,19 +41,6 @@ namespace MouseUnSnag.Configuration
                     return;
                 
                 _wrap = value;
-                OnConfigChanged();
-            }
-        }
-
-        public bool Rescale
-        {
-            get => _rescale;
-            set
-            {
-                if (_rescale == value)
-                    return;
-                
-                _rescale = value;
                 OnConfigChanged();
             }
         }

--- a/MouseUnSnag/Configuration/OptionsSerializer.cs
+++ b/MouseUnSnag/Configuration/OptionsSerializer.cs
@@ -33,7 +33,6 @@ namespace MouseUnSnag.Configuration
                 throw new ArgumentNullException(nameof(options));
 
             var opts = new List<(string name, object value)>();
-            opts.Add(("Rescale", options.Rescale));
             opts.Add(("Wrap   ", options.Wrap));
             opts.Add(("Jump   ", options.Jump));
             opts.Add(("Unstick", options.Unstick));
@@ -66,9 +65,6 @@ namespace MouseUnSnag.Configuration
                 {
                     switch (optionName.ToUpperInvariant())
                     {
-                        case "RESCALE":
-                            options.Rescale = bool.Parse(optionValue);
-                            break;
                         case "WRAP":
                             options.Wrap = bool.Parse(optionValue);
                             break;

--- a/MouseUnSnag/MouseLogic.cs
+++ b/MouseUnSnag/MouseLogic.cs
@@ -124,7 +124,7 @@ namespace MouseUnSnag
                 if (!Options.Unstick)
                     return false;
 
-                newCursor = Options.Rescale ? RescaleY(mouse, cursorScreen.Bounds, mouseScreen.Bounds) : mouse;
+                newCursor = mouse;
             }
             else if (jumpScreen != null)
             {
@@ -137,7 +137,7 @@ namespace MouseUnSnag
                 if (!Options.Jump)
                     return false;
 
-                newCursor = jumpScreen.Bounds.ClosestBoundaryPoint(Options.Rescale ? RescaleY(cursor, cursorScreen.Bounds, jumpScreen.Bounds) : cursor);
+                newCursor = jumpScreen.Bounds.ClosestBoundaryPoint(cursor);
             }
             else if (stuckDirection.X != 0)
             {
@@ -155,12 +155,6 @@ namespace MouseUnSnag
                     return false;
                 }
 
-                if (Options.Rescale)
-                {
-                    // Currently does not work properly. Wrapping from small screen bottom half to big screen appears to set the newCursor Position correctly, but the actual cursor does not move there.
-                    //wrapPoint = RescaleY(wrapPoint, cursorScreen.Bounds, wrapScreen.Bounds);
-                }
-
                 newCursor = wrapScreen.Bounds.ClosestBoundaryPoint(wrapPoint);
             }
             else
@@ -174,15 +168,6 @@ namespace MouseUnSnag
             return true;
         }
 
-        
-
-        private static Point RescaleY(Point p, Rectangle source, Rectangle destination)
-        {
-            if (Math.Abs(source.Top - destination.Top) > 20)
-                return p;
-
-            return p.RescaleY(source, destination);
-        }
 
         public event EventHandler<BoundsChangedEventArgs> LastCursorBoundsChanged;
         protected virtual void OnLastCursorBoundsChanged(BoundsChangedEventArgs e)

--- a/MouseUnSnag/Program.cs
+++ b/MouseUnSnag/Program.cs
@@ -35,7 +35,7 @@ namespace MouseUnSnag
                 Win32Display.SetDpiAwareness(ProcessDpiAwareness.ProcessPerMonitorDpiAware);
 
                 // Load Config from File
-                var optionsFilename = Path.Combine(GetOptionsDirectory(), "snagConfig", "snagConfig.txt");
+                var optionsFilename = Path.Combine(GetOptionsDirectory(), "config.txt");
                 var writer = new OptionsWriter(optionsFilename);
                 var options = writer.TryRead();
 
@@ -62,20 +62,17 @@ namespace MouseUnSnag
         {
             try
             {
-                var assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                if (!string.IsNullOrEmpty(assemblyDir) && Directory.Exists(assemblyDir))
-                    return assemblyDir;
+                var optionsDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                if (!string.IsNullOrEmpty(optionsDir))
+                    return Path.Combine(optionsDir, "MouseUnSnag");
             }
             catch (ArgumentException e)
             {
                 Debug.WriteLine(e);
             }
 
-            var cliDirName = Environment.GetCommandLineArgs().First();
-            if (!string.IsNullOrEmpty(cliDirName) && Directory.Exists(cliDirName))
-                return cliDirName;
-
-            return Environment.CurrentDirectory;
+            Debug.WriteLine("Couldn't find AppData, falling back to current directory for config file");
+            return Path.Combine(Environment.CurrentDirectory, "MouseUnSnag");
         }
 
         private static int ShowAlreadyRunningMessageAndQuit()

--- a/MouseUnSnag/TrayIconApplicationContext.cs
+++ b/MouseUnSnag/TrayIconApplicationContext.cs
@@ -74,15 +74,6 @@ namespace MouseUnSnag
                 {
                     Checked = options.Wrap
                 },
-                new MenuItem("Rescale Pointer between Screens", (sender, _) =>
-                {
-                    var item = (MenuItem) sender;
-                    options.Rescale = !options.Rescale;
-                    item.Checked = options.Rescale;
-                })
-                {
-                    Checked = options.Rescale
-                },
 
                 new MenuItem("Exit", delegate
                 {

--- a/MouseUnSnagTests/CommandLine/CommandLineParserTests.cs
+++ b/MouseUnSnagTests/CommandLine/CommandLineParserTests.cs
@@ -17,7 +17,6 @@ namespace MouseUnSnag.CommandLine.Tests
                 var opts = new List<string>();
                 opts.Add(options.Wrap ? "+w" : "-w");
                 opts.Add(options.Jump ? "+j" : "-j");
-                opts.Add(options.Rescale ? "+r" : "-r");
                 opts.Add(options.Unstick ? "+s" : "-s");
 
                 OptionsHelpers.Compare(options, parser.Decode(opts));
@@ -39,9 +38,6 @@ namespace MouseUnSnag.CommandLine.Tests
 
                     if (options.Jump != backingOptions.Jump)
                         opts.Add(options.Jump ? "+j" : "-j");
-
-                    if (options.Rescale != backingOptions.Rescale)
-                        opts.Add(options.Rescale ? "+r" : "-r");
 
                     if (options.Unstick != backingOptions.Unstick)
                         opts.Add(options.Unstick ? "+s" : "-s");

--- a/MouseUnSnagTests/Configuration/OptionsHelpers.cs
+++ b/MouseUnSnagTests/Configuration/OptionsHelpers.cs
@@ -19,7 +19,6 @@ namespace MouseUnSnagTests.Configuration
             Assert.AreEqual(expected.Jump, actual.Jump);
             Assert.AreEqual(expected.Wrap, actual.Wrap);
             Assert.AreEqual(expected.Unstick, actual.Unstick);
-            Assert.AreEqual(expected.Rescale, actual.Rescale);
         }
 
         public static IEnumerable<Options> OptionPermutations()
@@ -30,7 +29,7 @@ namespace MouseUnSnagTests.Configuration
                 foreach (var rescale in boolList)
                     foreach (var unstick in boolList)
                         foreach (var wrap in boolList)
-                            yield return new Options() { Jump = jump, Rescale = rescale, Unstick = unstick, Wrap = wrap};
+                            yield return new Options() { Jump = jump, Unstick = unstick, Wrap = wrap};
 
         }
 

--- a/MouseUnSnagTests/Configuration/OptionsTests.cs
+++ b/MouseUnSnagTests/Configuration/OptionsTests.cs
@@ -16,14 +16,11 @@ namespace MouseUnSnag.Configuration.Tests
             options.Jump = !options.Jump;
             Assert.AreEqual(1, events);
 
-            options.Rescale = !options.Rescale;
+            options.Unstick = !options.Unstick;
             Assert.AreEqual(2, events);
 
-            options.Unstick = !options.Unstick;
-            Assert.AreEqual(3, events);
-
             options.Wrap = !options.Wrap;
-            Assert.AreEqual(4, events);
+            Assert.AreEqual(3, events);
 
         }
     }

--- a/README.md
+++ b/README.md
@@ -33,9 +33,19 @@ The program endeavors to fix two separate problems related to multiple monitors,
 
 3. **MouseUnSnag** also wraps the cursor around from the right edge of the rightmost monitor, to the left edge of the leftmost monitor, and vice versa. (I don't have a fancy graphic for that one!)
 
-## Command Line Options
+## Configuration
 
-The MouseUnSnag executable takes the following command line options in the format: `MouseUnSnag.exe [options ...]`. All options are enabled by default.
+MouseUnSnag can be configured in two ways: by using command line options or by selecting options in system tray icon's context menu. Options selected in the context menu are persisted to _%APPDATA%/MouseUnSnag/config.txt_. Options specified on the command line override option in the configuration file but are not persisted. The configuration file is only created if options are changed using the context menu, so MouseUnSnag is stateless if only command line options are used.
+
+The configuration file consists of a list of "name:value" statements, each on their own line (extra whitespace within a line is ignored). For example:
+
+```
+Wrap   :false
+Jump   :false
+Unstick:true
+```
+
+MouseUnSnag takes the following command line options in the format: `MouseUnSnag.exe [options ...]`. All options are enabled by default.
 
 * `-s`, `+s`
 
@@ -43,11 +53,11 @@ The MouseUnSnag executable takes the following command line options in the forma
 
 * `-j`, `+j`
 
-  Disable or enable respectively jumping the mose from an edge to the adjacent monitor.
+  Disable or enable respectively jumping the cursor from an edge to the adjacent monitor.
 
 * `-w`, `+w`
 
-  Disable or enable respectively wraping the cursor from one far edge to the other.
+  Disable or enable respectively wrapping the cursor from one far edge to the other.
 
 ## How does it do it?
 **MouseUnSnag** uses the low-level Win32 WH_MOUSE_LL callback to monitor the user's intended movement of the mouse. It also monitors the current position of the cursor on the screen. When **MouseUnSnag** detects that the mouse has tried to move beyond the edge/corner of the screen, but the cursor was not able to move, then it knows that the cursor is "stuck", and will attempt to sensibly move the cursor to an adjacent monitor, if one exists.


### PR DESCRIPTION
These changes address the two remaining issues for the v2.2 release, issues #8 and #11. Additionally, they move the config file location into AppData and add artifacts of the release executable to the build workflow to ease testing.

Summary of included commits:

- Remove "Rescale pointer between screens" option
- Save config file to AppData instead of executable directory
- Document settings retention
- Upload executable artifact in build workflow